### PR TITLE
created bottom nav bar in AppMainScreen with icons

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:recipe_app/views/app_main_screen.dart';
 
 void main() async{
   WidgetsFlutterBinding.ensureInitialized();
@@ -35,7 +36,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.blueAccent),
         useMaterial3: true,
       ),
-      home: const MyHomePage(title: 'Flutter Demo'),
+      home: const AppMainScreen(),
     );
   }
 }

--- a/lib/utils/constraints.dart
+++ b/lib/utils/constraints.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/material.dart';
+
+const kbackgroundColor = Color(0xffeff1f7);
+const kprimaryColor = Color(0xff568A9f);
+const kBannerColor = Color(0xff579f8c);

--- a/lib/views/app_main_screen.dart
+++ b/lib/views/app_main_screen.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:iconsax/iconsax.dart';
+import 'package:recipe_app/utils/constraints.dart';
+class AppMainScreen extends StatefulWidget {
+  const AppMainScreen({super.key});
+
+  @override
+  State<AppMainScreen> createState() => _AppMainScreenState();
+}
+
+class _AppMainScreenState extends State<AppMainScreen> {
+  int selectedIndex = 0;
+  late final List<Widget> page;
+  @override
+  void initState() {
+
+    super.initState();
+  }
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      bottomNavigationBar: BottomNavigationBar(
+          backgroundColor: Colors.white,
+          elevation: 0,
+          iconSize: 28,
+          currentIndex: selectedIndex,
+          selectedItemColor:kprimaryColor,
+          unselectedItemColor: Colors.grey,
+          type: BottomNavigationBarType.fixed,
+          selectedLabelStyle: TextStyle(
+              color: kprimaryColor,
+              fontWeight: FontWeight.w600
+          ),
+          unselectedLabelStyle: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w500
+          ),
+          onTap: (value){
+            setState(() {
+              selectedIndex = value;
+            });
+          },
+          items: [
+            BottomNavigationBarItem(
+                icon: Icon(
+                  selectedIndex ==0 ? Iconsax.home5 : Iconsax.home_1,
+            ),
+              label: "Home",
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(
+                selectedIndex ==1 ? Iconsax.heart5 : Iconsax.heart,
+              ),
+              label: "Favorite",
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(
+                selectedIndex ==2 ? Iconsax.calendar5 : Iconsax.calendar,
+              ),
+              label: "Meal Plan",
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(
+                selectedIndex ==3 ? Iconsax.setting_21 : Iconsax.setting_2,
+              ),
+              label: "Setting",
+            ),
+          ]),
+    );
+  }
+  navBarPage(iconName){
+    return Center(
+      child: Icon(iconName,size: 100,color: kprimaryColor
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### This PR introduces the AppMainScreen widget, which serves as the main entry point for the recipe app. It includes:

1. A BottomNavigationBar to navigate between different sections (Home, Favorites, Meal Plan, and Settings).
2. Styling and navigation logic.
3. Constants defined in constraints.dart for maintaining consistent color usage across the app.

### Implementation Details

#### app_main_screen.dart
##### AppMainScreen Stateful Widget:

1. Manages the navigation state (selectedIndex) for switching between pages.
Uses a BottomNavigationBar with icons and labels for navigation.

##### BottomNavigationBar:

1. Four tabs: Home, Favorites, Meal Plan, and Settings.
2. Dynamically changes the icon based on the selected state (e.g., Iconsax.home5 for active, Iconsax.home_1 for inactive).

##### Styling:

1. Uses kprimaryColor for selected tab items to maintain design consistency.
2. Configures label styles for both selected and unselected states.